### PR TITLE
Feature/apply auth to edit

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -14,7 +14,12 @@ class LinksController < ApplicationController
   end
 
   def edit
-    @link = Link.find(params[:id])
+    if current_user.links.exists?(params[:id])
+      @link = Link.find(params[:id])
+    else
+      flash[:error] = "You do not have permission to access that page"
+      redirect_to root_path
+    end
   end
 
   def update

--- a/spec/integrations/visitor_can_edit_a_link_spec.rb
+++ b/spec/integrations/visitor_can_edit_a_link_spec.rb
@@ -13,8 +13,6 @@ RSpec.feature "A user can edit their links" do
 
       expect(current_path).to eq edit_link_path(link.id)
 
-      save_and_open_page
-
       fill_in "link_title", with: "Some other link"
       fill_in "link_url", with: "http://google.com"
       click_on "Update Thought"
@@ -29,9 +27,10 @@ RSpec.feature "A user can edit their links" do
   end
 
   context "invalid" do
-    scenario "They attempt to access the edit page for a link that isn't theirs'" do
+    scenario "They attempt to access the edit page for a link that isn't theirs" do
       user = create(:user)
       unowned_link = create(:link)
+
       login_user(user)
 
       visit edit_link_path(unowned_link)

--- a/spec/integrations/visitor_can_edit_a_link_spec.rb
+++ b/spec/integrations/visitor_can_edit_a_link_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.feature "A user can edit their links" do
+  context "valid" do
+    scenario "They visit the home page and edit one of their links" do
+      user = create(:user)
+      link = create(:link, user: user)
+      login_user(user)
+
+      within "#link-#{link.id}" do
+        click_on "Edit"
+      end
+
+      expect(current_path).to eq edit_link_path(link.id)
+
+      save_and_open_page
+
+      fill_in "link_title", with: "Some other link"
+      fill_in "link_url", with: "http://google.com"
+      click_on "Update Thought"
+
+      expect(current_path).to eq root_path
+
+      within "#link-#{link.id}" do
+        expect(page).to have_content "Some other link"
+        expect(page).to have_content "http://google.com"
+      end
+    end
+  end
+
+  context "invalid" do
+    scenario "They attempt to access the edit page for a link that isn't theirs'" do
+      user = create(:user)
+      unowned_link = create(:link)
+      login_user(user)
+
+      visit edit_link_path(unowned_link)
+
+      expect(current_path).to eq root_path
+      expect(page).to have_content "You do not have permission to access that page"
+    end
+  end
+end


### PR DESCRIPTION
Edit functionality now has an associated test case and checks for authorization before allowing someone to access the page.
- added a test case for editing thoughts
- added a test case for checking permissions for editing thoughts
- modified the edit page to check if the given link belongs to the current user
